### PR TITLE
Update dependencies due to Xray Security Violations

### DIFF
--- a/gradle-examples/4/gradle-example-ci-server/api/build.gradle
+++ b/gradle-examples/4/gradle-example-ci-server/api/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile module("commons-lang:commons-lang:2.4") {
         dependency("commons-io:commons-io:1.2")
     }
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    compile group: 'org.apache.wicket', name: 'wicket', version: '[7.0.0-M3]'
     compile group: 'commons-httpclient', name: 'commons-httpclient', version: '3.0'
 
 }

--- a/gradle-examples/4/gradle-example-ci-server/services/webservice/build.gradle
+++ b/gradle-examples/4/gradle-example-ci-server/services/webservice/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'war'
 dependencies {
     compile project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
     compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
-    compile group: 'org.apache.struts', name: 'struts2-core', version: '2.3.14'
+    compile group: 'org.apache.struts', name: 'struts2-core', version: '[2.3.14.3,2.3.15)'
     compile group: 'junit', name: 'junit', version: '4.11'
     compile project(':api')
 }


### PR DESCRIPTION
CVE-2014-3526: Apache Wicket before 1.5.12, 6.x before 6.17.0, and 7.x before 7.0.0-M3 might allow remote attackers to obtain sensitive information via vectors involving identifiers for storing page markup for temporary user sessions.
- org.apache.wicket:wicket:1.3.7 => [7.0.0-M3]

CVE-2014-3526: Apache Wicket before 1.5.12, 6.x before 6.17.0, and 7.x before 7.0.0-M3 might allow remote attackers to obtain sensitive information via vectors involving identifiers for storing page markup for temporary user sessions.
- org.apache.wicket:wicket:1.3.7 => [7.0.0-M3]

CVE-2013-2134: Arbitrary Code Injection
- org.apache.struts:struts2-core:2.3.14 => [2.3.14.3,2.3.15)

CVE-2015-5169: Cross-site Scripting (XSS)
- org.apache.struts:struts2-core:2.3.14 => [2.3.20,)

CVE-2017-5638: Arbitrary Code Execution
- org.apache.struts:struts2-core:2.3.14 => [2.3.32,2.5)

CVE-2014-0094: ClassLoader Manipulation via ParametersInterceptor
- org.apache.struts:struts2-core:2.3.14 => [2.3.16.2,3)

CVE-2013-1966: Arbitrary Code Injection
- org.apache.struts:struts2-core:2.3.14 => [2.3.14.2,2.3.15)

CVE-2013-4310: Bypass Access Controls
- org.apache.struts:struts2-core:2.3.14 => [2.3.15.3,2.3.16)

CVE-2013-2134: Apache Struts 2 before 2.3.14.3 allows remote attackers to execute arbitrary OGNL code via a request with a crafted action name that is not properly handled during wildcard matching, a different vulnerability than CVE-2013-2135.
- org.apache.struts:struts2-core:2.3.14 => [2.3.14.3]

CVE-2015-5209: Apache Struts 2.x before 2.3.24.1 allows remote attackers to manipulate Struts internals, alter user sessions, or affect container settings via vectors involving a top object.
- org.apache.struts:struts2-core:2.3.14 => [2.3.24.1]

CVE-2017-12611: In Apache Struts 2.0.1 through 2.3.33 and 2.5 through 2.5.10, using an unintentional expression in a Freemarker tag instead of string literals can lead to a RCE attack.
- org.apache.struts:struts2-core:2.3.14 => [2.3.34]

CVE-2013-2251: Remote command execution
- org.apache.struts:struts2-core:2.3.14 => [2.3.15.1,2.3.16)

CVE-2017-5638: The Jakarta Multipart parser in Apache Struts 2 2.3.x before 2.3.32 and 2.5.x before 2.5.10.1 mishandles file upload, which allows remote attackers to execute arbitrary commands via a #cmd= string in a crafted Content-Type HTTP header, as exploited in the wild in March 2017.
- org.apache.struts:struts2-core:2.3.14 => [2.3.32]

CVE-2014-7809: Cross-site Request Forgery (CSRF)
- org.apache.struts:struts2-core:2.3.14 => [2.3.20,)

CVE-2017-7525: A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, which could allow an unauthenticated user to perform code execution by sending the maliciously crafted input to the readValue method of the ObjectMapper.
- org.apache.struts:struts2-core:2.3.14 => [2.5.14.1]

CVE-2013-2248: URL Redirection to Untrusted Site
- org.apache.struts:struts2-core:2.3.14 => [2.3.15.1,2.3.16)

CVE-2017-9804: In Apache Struts 2.3.7 through 2.3.33 and 2.5 through 2.5.12, if an application allows entering a URL in a form field and built-in URLValidator is used, it is possible to prepare a special URL which will be used to overload server process when performing validation of the URL.  NOTE: this vulnerability exists because of an incomplete fix for S2-047 / CVE-2017-7672.
- org.apache.struts:struts2-core:2.3.14 => [2.3.34]

CVE-2013-4316: Dynamic Method Executions
- org.apache.struts:struts2-core:2.3.14 => [2.3.15.2,3)

CVE-2014-0113: ClassLoader manipulation via ParametersInterceptor
- org.apache.struts:struts2-core:2.3.14 => [2.3.16.2,)

CVE-2014-0116: Classloader manipulation via CookieInterceptor
- org.apache.struts:struts2-core:2.3.14 => [2.3.16.3,)

CVE-2013-2115: Arbitrary Code Injection
- org.apache.struts:struts2-core:2.3.14 => [2.3.14.2,2.3.15)

CVE-2014-0112: ClassLoader manipulation via ParametersInterceptor
- org.apache.struts:struts2-core:2.3.14 => [2.3.16.2,)

CVE-2015-5209: Manipulation of Struts' internals
- org.apache.struts:struts2-core:2.3.14 => [2.3.24.1,)

CVE-2015-5169: Cross-site scripting (XSS) vulnerability in Apache Struts before 2.3.20.
- org.apache.struts:struts2-core:2.3.14 => [2.3.20]

CVE-2016-3090: The TextParseUtil.translateVariables method in Apache Struts 2.x before 2.3.20 allows remote attackers to execute arbitrary code via a crafted OGNL expression with ANTLR tooling.
- org.apache.struts:struts2-core:2.3.14 => [2.3.24.1]

CVE-2013-2135: Arbitrary Code Injection
- org.apache.struts:struts2-core:2.3.14 => [2.3.14.3,2.3.15)