### PR TITLE
Update dependencies due to Xray Security Violations

### DIFF
--- a/gradle-examples/4/gradle-example-ci-server/api/build.gradle
+++ b/gradle-examples/4/gradle-example-ci-server/api/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile module("commons-lang:commons-lang:2.4") {
         dependency("commons-io:commons-io:1.2")
     }
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    compile group: 'org.apache.wicket', name: 'wicket', version: '[7.0.0-M3]'
     compile group: 'commons-httpclient', name: 'commons-httpclient', version: '3.0'
 
 }

--- a/gradle-examples/4/gradle-example-ci-server/services/webservice/build.gradle
+++ b/gradle-examples/4/gradle-example-ci-server/services/webservice/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'war'
 
 dependencies {
     compile project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    compile group: 'org.apache.wicket', name: 'wicket', version: '[7.0.0-M3]'
     compile group: 'org.apache.struts', name: 'struts2-core', version: '2.3.14'
     compile group: 'junit', name: 'junit', version: '4.11'
     compile project(':api')


### PR DESCRIPTION
CVE-2014-3526: Apache Wicket before 1.5.12, 6.x before 6.17.0, and 7.x before 7.0.0-M3 might allow remote attackers to obtain sensitive information via vectors involving identifiers for storing page markup for temporary user sessions.
- org.apache.wicket:wicket:1.3.7 => [7.0.0-M3]

CVE-2014-3526: Apache Wicket before 1.5.12, 6.x before 6.17.0, and 7.x before 7.0.0-M3 might allow remote attackers to obtain sensitive information via vectors involving identifiers for storing page markup for temporary user sessions.
- org.apache.wicket:wicket:1.3.7 => [7.0.0-M3]

CVE-2013-2134: Apache Struts 2 before 2.3.14.3 allows remote attackers to execute arbitrary OGNL code via a request with a crafted action name that is not properly handled during wildcard matching, a different vulnerability than CVE-2013-2135.
- org.apache.struts:struts2-core:2.3.14 => [2.3.14.3]